### PR TITLE
Rename imageUrl to url

### DIFF
--- a/framework/spree/utils/get-media-gallery.ts
+++ b/framework/spree/utils/get-media-gallery.ts
@@ -12,15 +12,10 @@ const getMediaGallery = (
   ) => string | null
 ) => {
   return images.reduce<ProductImage[]>((productImages, _, imageIndex) => {
-    const imageUrl = getImageUrl(images[imageIndex], 800, 800)
+    const url = getImageUrl(images[imageIndex], 800, 800)
 
-    if (imageUrl) {
-      return [
-        ...productImages,
-        {
-          url: imageUrl,
-        },
-      ]
+    if (url) {
+      return [...productImages, { url }]
     }
 
     return productImages


### PR DESCRIPTION
getMediaGallery already provides context for the constant