### PR TITLE
Remove return type for getProductPath

### DIFF
--- a/framework/spree/utils/get-product-path.ts
+++ b/framework/spree/utils/get-product-path.ts
@@ -1,6 +1,6 @@
 import type { ProductSlugAttr } from '../types'
 
-const getProductPath = (partialSpreeProduct: ProductSlugAttr): string => {
+const getProductPath = (partialSpreeProduct: ProductSlugAttr) => {
   return `/${partialSpreeProduct.attributes.slug}`
 }
 


### PR DESCRIPTION
The return type can be trivially determined from the returned value.